### PR TITLE
dev-121: Verification function for props and ports

### DIFF
--- a/shared/lib/api/entry-node.js
+++ b/shared/lib/api/entry-node.js
@@ -7,11 +7,13 @@ export class EntryNode extends BasicNode {
 	static ports = {
 		inputs: {},
 		outputs: {
-			props: {}
+			props: (x) => {
+				return (typeof x === 'object');
+			}
 		}
 	};
 
-	static executor = (props = EntryNode.props, input = EntryNode.ports.inputs) => {
+	static executor = (props = EntryNode.props, input) => {
 		return new Promise((resolve, reject) => {
 			resolve({
 				props: props

--- a/shared/lib/api/return-node.js
+++ b/shared/lib/api/return-node.js
@@ -6,12 +6,14 @@ export class ReturnNode extends BasicNode {
 
 	static ports = {
 		inputs: {
-			result: {}
+			result: (x) => {
+				return x;
+			}
 		},
 		outputs: {}
 	};
 
-	static executor = (props = ReturnNode.props, input = ReturnNode.ports.inputs) => {
+	static executor = (props = ReturnNode.props, input) => {
 		return new Promise((resolve, reject) => {
 			resolve(null);
 		});

--- a/shared/lib/basic-node.js
+++ b/shared/lib/basic-node.js
@@ -92,7 +92,19 @@ export class BasicNode {
 
 	receive(port, data, propagate = true) {
 		if (this.instance.inputs[port] === undefined) {
-			this.instance.inputs[port] = data;
+			try {
+				this.instance.inputs[port] = this.class.ports.inputs[port](data);
+			} catch (err) {
+				console.error(err);
+				throw {
+					message: "invalid parameter",
+					error: {
+						ref: this,
+						port: port,
+						data: data
+					}
+				};
+			}
 			if (propagate && this.isReady()) {
 				this.execute();
 			}
@@ -116,6 +128,16 @@ export class BasicNode {
 	setProps(props = {}) {
 		this.props = Object.keys(props).reduce((accumulator, current) => {
 			if (this.class.props.hasOwnProperty(current)) {
+				if (typeof this.class.props[current] !== typeof props[current]) {
+					throw {
+						message: "invalid prop",
+						error: {
+							ref: this,
+							prop: current,
+							data: props[current]
+						}
+					};
+				}
 				accumulator[current] = props[current];
 			}
 			return accumulator;

--- a/shared/lib/primitive/bool-node.js
+++ b/shared/lib/primitive/bool-node.js
@@ -9,11 +9,13 @@ export class BoolNode extends BasicNode {
 	static ports = {
 		inputs: {},
 		outputs: {
-			bool: false
+			bool: (x) => {
+				return (typeof x === 'boolean');
+			}
 		}
 	};
 
-	static executor = (props = BoolNode.props, input = BoolNode.ports.inputs) => {
+	static executor = (props = BoolNode.props, inputs) => {
 		return new Promise((resolve, reject) => {
 			resolve({
 				bool: props.bool
@@ -21,7 +23,7 @@ export class BoolNode extends BasicNode {
 		});
 	};
 
-	constructor(props = BoolNode.props) {
+	constructor(props) {
 		super({
 			class: BoolNode,
 			props: props

--- a/shared/lib/primitive/number-node.js
+++ b/shared/lib/primitive/number-node.js
@@ -9,19 +9,21 @@ export class NumberNode extends BasicNode {
 	static ports = {
 		inputs: {},
 		outputs: {
-			number: 0
+			number: (x) => {
+				return (typeof x === 'number');
+			}
 		}
 	};
 
-	static executor = (props = NumberNode.props, inputs = NumberNode.ports.inputs) => {
+	static executor = (props = NumberNode.props, inputs) => {
 		return new Promise((resolve, reject) => {
 			resolve({
-				number: (typeof props.number === 'number') ? props.number : parseFloat(props.number)
+				number: props.number
 			});
 		});
 	};
 
-	constructor(props = NumberNode.props) {
+	constructor(props) {
 		super({
 			class: NumberNode,
 			props: props

--- a/shared/lib/primitive/string-node.js
+++ b/shared/lib/primitive/string-node.js
@@ -9,15 +9,27 @@ export class StringNode extends BasicNode {
 	static ports = {
 		inputs: {},
 		outputs: {
-			string: ''
+			string: (x) => {
+				return (typeof x === 'string');
+			}
 		}
 	};
 
-	static executor = (props = StringNode.props, input = StringNode.ports.inputs) => {
+	static executor = (props = StringNode.props, inputs) => {
 		return new Promise((resolve, reject) => {
-			resolve({
-				string: props['string']
-			});
+			if (typeof props.string === 'string') {
+				resolve({
+					string: props.string
+				});
+				return;
+			}
+			try {
+				resolve({
+					string: JSON.stringify(props.string)
+				})
+			} catch (err) {
+				reject(err);
+			}
 		});
 	};
 


### PR DESCRIPTION
Provides verification of data types for ```props``` and ```ports```

- ```BasicNode.setProps``` now throws an error if there is a data type mismatch
- ```BasicNode.receive``` now throws an error if there is a data type mismatch

closes #121 
